### PR TITLE
Changed contact.css input text color to black (visibile)

### DIFF
--- a/css/contact.css
+++ b/css/contact.css
@@ -16,6 +16,7 @@
     border: 1px solid rgba(255, 255, 255, 0.18);
 }
 
+
 @keyframes gradient-animation {
     0%{
         background-position: 0% 50%;
@@ -58,6 +59,7 @@ fieldset label {
     margin: 5px 0 10px;
     padding: 10px;
     border-radius: 20px;
+    color: #000;
 }
 
 #contact input[type="text"]:hover,


### PR DESCRIPTION
## What does this PR do?

Changes made in contact.css. Added color black for input text so the text and cursor in contact page is visibile.

Fixes #(issue)

![Screenshot_20241018_161933](https://github.com/user-attachments/assets/0a9b708e-1b15-4b17-8dbd-5f0862e5c614)


## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How should this be tested?

- Visit contact page and try to fill the contact form the information you provide in the input field will now visibile.

